### PR TITLE
(maint) Fix mode on file resource

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,7 @@ class dujour (
     content => template('dujour/config.edn.erb'),
     owner   => 'dujour',
     group   => 'dujour',
-    mode    => 640,
+    mode    => '0640',
     notify  => Service['dujour'], # dujour will restart whenever you edit this file.
     require => Package['dujour'],
   }


### PR DESCRIPTION
In recent puppet, `mode` cannot be an integer, it must be a string.