### PR TITLE
(maint) Properly set the setting metaparam

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,13 +40,13 @@ class dujour (
     require => Package['dujour'],
   }
 
-  hocon_setting { 'web-router-service':
-    ensure  => present,
-    path    => "${config_dir}/conf.d/dujour.conf",
-    setting => 'web-router-service.dujour.core/dujour-service',
-    value   => "",
-    require => Package['dujour'],
-  }
+  #hocon_setting { 'web-router-service':
+  #  ensure  => present,
+  #  path    => "${config_dir}/conf.d/dujour.conf",
+  #  setting => 'web-router-service.dujour.core/dujour-service',
+  #  value   => "",
+  #  require => Package['dujour'],
+  #}
 
   hocon_setting { 'database.classname':
     ensure  => present,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,7 @@ class dujour (
   hocon_setting { 'global.logging-config':
     ensure  => present,
     path    => "${config_dir}/conf.d/dujour.conf",
-    setting => 'logging-config',
+    setting => 'global.logging-config',
     value   => "${config_dir}/logback.xml",
     require => Package['dujour'],
   }
@@ -27,7 +27,7 @@ class dujour (
   hocon_setting { 'webserver.host':
     ensure  => present,
     path    => "${config_dir}/conf.d/dujour.conf",
-    setting => 'host',
+    setting => 'webserver.host',
     value   => $host,
     require => Package['dujour'],
   }
@@ -35,7 +35,7 @@ class dujour (
   hocon_setting { 'webserver.port':
     ensure  => present,
     path    => "${config_dir}/conf.d/dujour.conf",
-    setting => 'port',
+    setting => 'webserver.port',
     value   => $port,
     require => Package['dujour'],
   }
@@ -43,7 +43,7 @@ class dujour (
   hocon_setting { 'web-router-service':
     ensure  => present,
     path    => "${config_dir}/conf.d/dujour.conf",
-    setting => 'dujour.core/dujour-service',
+    setting => 'web-router-service.dujour.core/dujour-service',
     value   => "",
     require => Package['dujour'],
   }
@@ -51,7 +51,7 @@ class dujour (
   hocon_setting { 'database.classname':
     ensure  => present,
     path    => "${config_dir}/conf.d/dujour.conf",
-    setting => 'classname',
+    setting => 'database.classname',
     value   => 'org.postgresql.Driver',
     require => Package['dujour'],
   }
@@ -59,7 +59,7 @@ class dujour (
   hocon_setting { 'database.subprotocol':
     ensure  => present,
     path    => "${config_dir}/conf.d/dujour.conf",
-    setting => 'subprotocol',
+    setting => 'database.subprotocol',
     value   => 'postgresql',
     require => Package['dujour'],
   }
@@ -67,7 +67,7 @@ class dujour (
   hocon_setting { 'database.username':
     ensure  => present,
     path    => "${config_dir}/conf.d/dujour.conf",
-    setting => 'username',
+    setting => 'database.username',
     value   => $database_username,
     require => Package['dujour'],
   }
@@ -75,7 +75,7 @@ class dujour (
   hocon_setting { 'database.password':
     ensure  => present,
     path    => "${config_dir}/conf.d/dujour.conf",
-    setting => 'password',
+    setting => 'database.password',
     value   => $database_password,
     require => Package['dujour'],
   }
@@ -83,7 +83,7 @@ class dujour (
   hocon_setting { 'database.subname':
     ensure  => present,
     path    => "${config_dir}/conf.d/dujour.conf",
-    setting => 'subname',
+    setting => 'database.subname',
     value   => "//${database_host}:${database_port}/${database_name}",
     require => Package['dujour'],
   }


### PR DESCRIPTION
This commit fixes a bug in the dujour module where the hocon settings
were not being properly placed in the right keys because of how the
setting metaparam was set.
